### PR TITLE
use recursive option with git clone

### DIFF
--- a/app/Http/Controllers/Packages/PackageVersionsController.php
+++ b/app/Http/Controllers/Packages/PackageVersionsController.php
@@ -676,7 +676,7 @@ class PackageVersionsController extends BaseController {
 				//
 				$result = `mkdir $workdir;
 				 cd $workdir;
-				 git clone $external_url`;
+				 git clone --recursive $external_url`;
 
 				$files = scandir($workdir);
 				if (sizeof( $files ) !== 3) {


### PR DESCRIPTION
Building packages like https://github.com/bro/bro fails unless git clone --recursive is used.
